### PR TITLE
fix(server): pre-register event

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -215,6 +215,10 @@ class SimpleServer implements SimpleShared {
 			connection.Disconnect();
 		});
 	}
+	
+	register(name: string) {
+		RemoteManager.CreateEvent(name);
+	}
 }
 
 class SimpleClient implements SimpleShared {


### PR DESCRIPTION
This allows server to notify SimpleSignals that it needs to create an event in ReplicatedStorage, which will be used later.
This allows client code to find the event before it's fired, and prevent "Infinite Yield Possible"